### PR TITLE
Adding the constant StrictMode

### DIFF
--- a/ad_group_ads.go
+++ b/ad_group_ads.go
@@ -27,7 +27,9 @@ func (a1 AdGroupAds) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	case TemplateAd:
 		return ERROR_NOT_YET_IMPLEMENTED
 	default:
-		return fmt.Errorf("unknown Ad type -> %#v", start)
+		if StrictMode {
+			return fmt.Errorf("unknown Ad type -> %#v", start)
+		}
 	}
 	e.EncodeToken(start.End())
 	return nil
@@ -82,7 +84,9 @@ func (aga *AdGroupAds) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 					}
 					ad = a
 				default:
-					return fmt.Errorf("unknown AdGroupCriterion -> %#v", start)
+					if StrictMode {
+						return fmt.Errorf("unknown AdGroupCriterion -> %#v", start)
+					}
 				}
 			case "status":
 				err := dec.DecodeElement(&status, &start)

--- a/ad_group_criterion.go
+++ b/ad_group_criterion.go
@@ -55,7 +55,9 @@ func (agcs *AdGroupCriterions) UnmarshalXML(dec *xml.Decoder, start xml.StartEle
 		}
 		*agcs = append(*agcs, nagc)
 	default:
-		return fmt.Errorf("unknown AdGroupCriterion -> %#v", adGroupCriterionType)
+		if StrictMode {
+			return fmt.Errorf("unknown AdGroupCriterion -> %#v", adGroupCriterionType)
+		}
 	}
 	return nil
 }

--- a/base.go
+++ b/base.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	baseUrl = "https://adwords.google.com/api/adwords/cm/v201409"
+	// used for developpement, if true all unknown field will raise an error
+	StrictMode = false
 )
 
 type ServiceUrl struct {
@@ -198,7 +200,7 @@ func (a *Auth) request(serviceUrl ServiceUrl, action string, body interface{}) (
 	}
 	if resp.StatusCode == 400 || resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 405 || resp.StatusCode == 500 {
 		fault := Fault{}
-		fmt.Printf("unknown error ->\n%s\n", string(soapResp.Body.Response))
+		// fmt.Printf("unknown error ->\n%s\n", string(soapResp.Body.Response))
 		err = xml.Unmarshal(soapResp.Body.Response, &fault)
 		if err != nil {
 			return respBody, err

--- a/biddable_ad_group_criterion.go
+++ b/biddable_ad_group_criterion.go
@@ -23,6 +23,7 @@ type BiddableAdGroupCriterion struct {
 
 	BiddingStrategyConfiguration *BiddingStrategyConfiguration `xml:"biddingStrategyConfiguration,omitempty"`
 	BidModifier                  int64                         `xml:"bidModifier,omitempty"`
+	FinalUrls                    FinalUrls                     `xml:"finalUrls,omitempty"`
 }
 
 func (bagc BiddableAdGroupCriterion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -107,6 +108,10 @@ func (bagc *BiddableAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.S
 				}
 			case "bidModifier":
 				if err := dec.DecodeElement(&bagc.BidModifier, &start); err != nil {
+					return err
+				}
+			case "finalUrls":
+				if err := dec.DecodeElement(&bagc.FinalUrls, &start); err != nil {
 					return err
 				}
 			case "AdGroupCriterion.Type":

--- a/biddable_ad_group_criterion.go
+++ b/biddable_ad_group_criterion.go
@@ -115,9 +115,15 @@ func (bagc *BiddableAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.S
 					return err
 				}
 			case "AdGroupCriterion.Type":
-				break
+				continue
+			case "labels":
+				continue
 			default:
-				return fmt.Errorf("unknown BiddableAdGroupCriterion field %s", tag)
+				if StrictMode {
+					return fmt.Errorf("unknown BiddableAdGroupCriterion field %s", tag)
+				} else {
+					continue
+				}
 			}
 		}
 	}

--- a/criterion.go
+++ b/criterion.go
@@ -283,7 +283,11 @@ func criterionUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Criterion,
 		err := dec.DecodeElement(&c, &start)
 		return c, err
 	default:
-		return nil, fmt.Errorf("unknown criterion type %#v", criterionType)
+		if StrictMode {
+			return nil, fmt.Errorf("unknown criterion type %#v", criterionType)
+		} else {
+			return nil, nil
+		}
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -64,6 +64,13 @@ type RateExceededError struct {
 	RetryAfterSeconds uint   `xml:"retryAfterSeconds"` // Try again in...
 }
 
+type UnknownError struct {
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
+}
+
 type ApiExceptionFault struct {
 	Message string        `xml:"message"`
 	Type    string        `xml:"ApplicationException.Type"`
@@ -115,7 +122,9 @@ func (aes *ApiExceptionFault) UnmarshalXML(dec *xml.Decoder, start xml.StartElem
 					dec.DecodeElement(&e, &start)
 					aes.Errors = append(aes.Errors, e)
 				default:
-					return fmt.Errorf("Unknown error type -> %s", start)
+					e := UnknownError{}
+					dec.DecodeElement(&e, &start)
+					aes.Errors = append(aes.Errors, e)
 				}
 			case "reason":
 				break

--- a/negative_ad_group_criterion.go
+++ b/negative_ad_group_criterion.go
@@ -47,7 +47,9 @@ func (nagc *NegativeAdGroupCriterion) UnmarshalXML(dec *xml.Decoder, start xml.S
 			case "AdGroupCriterion.Type":
 				break
 			default:
-				return fmt.Errorf("unknown NegativeAdGroupCriterion field %s", tag)
+				if StrictMode {
+					return fmt.Errorf("unknown NegativeAdGroupCriterion field %s", tag)
+				}
 			}
 		}
 	}

--- a/urls.go
+++ b/urls.go
@@ -1,0 +1,5 @@
+package gads
+
+type FinalUrls struct {
+	Urls []string `json:urls,omitempty`
+}


### PR DESCRIPTION
This constants aims to deactivate strict attitude if the library encounters a fields that is not managed by it. Because I'm operating on many type of google adwords entities, sometimes the library gives me an error only because it doesn't recognize a field that is not managed (but that have no impacts on work). It adds the UnknowError type too.